### PR TITLE
feat: integrate erc721 clan contract

### DIFF
--- a/contract/src/contracts/clan_nft.cairo
+++ b/contract/src/contracts/clan_nft.cairo
@@ -1,0 +1,82 @@
+#[starknet::contract]
+pub mod ClanNFT {
+    use contract::interfaces::IClanNFT::IClanNFT;
+    use core::array::ArrayTrait;
+    use openzeppelin::access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use starknet::ContractAddress;
+    use starknet::storage::{
+        Map, MutableVecTrait, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+        Vec,
+    };
+
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+
+    #[abi(embed_v0)]
+    impl ERC721MixinImpl = ERC721Component::ERC721MixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
+    impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+
+    #[storage]
+    struct Storage {
+        // ERC721 storage
+        #[substorage(v0)]
+        erc721: ERC721Component::Storage,
+        // SRC5 storage
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        // AccessControl storage
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
+        // Clan contract address
+        clan_contract: ContractAddress,
+    }
+
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState, name: ByteArray, symbol: ByteArray, clan_contract: ContractAddress,
+    ) {
+        let base_uri: ByteArray = "ipfs://";
+
+        self.accesscontrol.initializer();
+        self.erc721.initializer(name, symbol, base_uri);
+        self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, clan_contract);
+        self.clan_contract.write(clan_contract);
+    }
+
+    #[abi(embed_v0)]
+    impl ClanNFTImpl of IClanNFT<ContractState> {
+        /// Create a new clan
+        fn mint_nft(ref self: ContractState, token_id: u256, recipient: ContractAddress) {
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            let data: Span<felt252> = array![0].span();
+            self.erc721.safe_mint(recipient, token_id, data);
+        }
+
+        /// Burn an NFT for the clan
+        fn burn_nft(ref self: ContractState, token_id: u256) {
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            self.erc721.burn(token_id);
+        }
+    }
+}

--- a/contract/src/interfaces/IClanNFT.cairo
+++ b/contract/src/interfaces/IClanNFT.cairo
@@ -1,0 +1,9 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IClanNFT<TContractState> {
+    /// Mint a new NFT for the clan
+    fn mint_nft(ref self: TContractState, token_id: u256, recipient: ContractAddress);
+    /// Burn an NFT for the clan
+    fn burn_nft(ref self: TContractState, token_id: u256);
+}

--- a/contract/src/interfaces/IClanSystem.cairo
+++ b/contract/src/interfaces/IClanSystem.cairo
@@ -1,3 +1,4 @@
+use contract::interfaces::IClanNFT::IClanNFTDispatcher;
 use contract::structs::clanstruct::Clan;
 use starknet::ContractAddress;
 
@@ -5,17 +6,28 @@ use starknet::ContractAddress;
 #[starknet::interface]
 pub trait IClanSystem<TContractState> {
     /// Create a new clan
-    fn create_clan(ref self: TContractState, name: ByteArray, symbol: ByteArray);
+    fn create_clan(ref self: TContractState, name: ByteArray, symbol: ByteArray, token_id: u256);
 
     /// Join an existing clan
-    fn join_clan(ref self: TContractState, clan_id: felt252);
+    fn join_clan(ref self: TContractState, clan_id: felt252, token_id: u256);
 
     /// Leave current clan
-    fn leave_clan(ref self: TContractState);
+    fn leave_clan(ref self: TContractState, token_id: u256);
+
+    // Create a new NFT contract for the clan
+    fn create_clan_nft(
+        ref self: TContractState, name: ByteArray, symbol: ByteArray, clan_id: felt252,
+    );
 
     /// Get clan information
     fn get_clan_info(self: @TContractState, clan_id: felt252) -> Clan;
 
     /// Get user's current clan ID
     fn get_user_clan(self: @TContractState, user: ContractAddress) -> felt252;
+
+    /// Get the NFT contract of the clan with the given ID
+    fn get_clan_nft(self: @TContractState, clan_id: felt252) -> ContractAddress;
+
+    // Get the NFT dispatcher for the clan with the given ID
+    fn get_nft_dispatcher(self: @TContractState, clan_id: felt252) -> IClanNFTDispatcher;
 }

--- a/contract/src/interfaces/IQuadraticVoting.cairo
+++ b/contract/src/interfaces/IQuadraticVoting.cairo
@@ -1,10 +1,12 @@
-use starknet::ContractAddress;
 use contract::structs::votestructs::{ProposalStatus, Vote};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IQuadraticVoting<TContractState> {
     // / Create a new proposal
-    fn create_proposal(ref self: TContractState, description: ByteArray, vote_expiration_time: u64) -> u64;
+    fn create_proposal(
+        ref self: TContractState, description: ByteArray, vote_expiration_time: u64,
+    ) -> u64;
 
     // / Get proposal tally
     fn set_proposal_to_tally(ref self: TContractState, proposal_id: u64);
@@ -37,7 +39,9 @@ pub trait IQuadraticVoting<TContractState> {
     fn _approve(ref self: TContractState, spender: ContractAddress, amount: u256);
 
     // Transfer tokens from one address to another
-    fn _transfer_from(ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256);
+    fn _transfer_from(
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
+    );
 
     // Get balance of an address
     fn _balance_of(self: @TContractState, account: ContractAddress) -> u256;

--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -1,4 +1,5 @@
 pub mod interfaces {
+    pub mod IClanNFT;
     pub mod IClanSystem;
     pub mod IQuadraticVoting;
 }
@@ -10,5 +11,6 @@ pub mod structs {
 
 pub mod contracts {
     pub mod clan;
+    pub mod clan_nft;
     pub mod vote;
 }

--- a/contract/src/structs/votestructs.cairo
+++ b/contract/src/structs/votestructs.cairo
@@ -25,7 +25,7 @@ pub struct Proposal {
     pub description: ByteArray,
     pub voters: Vec<ContractAddress>,
     pub expiration_time: u64,
-    pub voter_info: Map::<ContractAddress, Voter>,
+    pub voter_info: Map<ContractAddress, Voter>,
 }
 
 #[derive(Drop, Serde, starknet::Store)]


### PR DESCRIPTION
Closes #10 

This PR does the following:
- Modify the flow when someone creates, joins and leaves a clan to the following:
Creates a clan -> Creates the NFT contract for the clan and mints an NFT for the creator
Joins a clan -> Mints an NFT 
Leave a clan -> Burns the NFT
- Add function to get the dispatcher of the NFT contract in the Contract clan.
- Add function to create the NFT contract
- Add the NFT smart contract with `mint` (using `safe_mint`) and `burn` functions. 
- Run `scarb fmt` for consistent formatting across the project.